### PR TITLE
Convert event data to m/s^2.

### DIFF
--- a/Adafruit_MMA8451.cpp
+++ b/Adafruit_MMA8451.cpp
@@ -231,9 +231,10 @@ bool Adafruit_MMA8451::getEvent(sensors_event_t *event) {
 
   read();
 
-  event->acceleration.x = x_g;
-  event->acceleration.y = y_g;
-  event->acceleration.z = z_g;
+  // Convert Acceleration Data to m/s^2
+  event->acceleration.x = x_g * SENSORS_GRAVITY_STANDARD;
+  event->acceleration.y = y_g * SENSORS_GRAVITY_STANDARD;
+  event->acceleration.z = z_g * SENSORS_GRAVITY_STANDARD;
 
   return true;
 }


### PR DESCRIPTION
As [here](https://github.com/adafruit/Adafruit_Sensor/blob/master/Adafruit_Sensor.h#L110) defined, the acceleration vector of `sensors_event_t` should be of unit m/s^2.

The [example](https://github.com/adafruit/Adafruit_MMA8451_Library/blob/master/examples/MMA8451demo/MMA8451demo.ino#L61) also claims, that the unit is m/s^2, although it's printed in g.
