### PR TITLE
Make readRegister8() protected

### DIFF
--- a/Adafruit_MMA8451.h
+++ b/Adafruit_MMA8451.h
@@ -116,8 +116,9 @@ class Adafruit_MMA8451
   float x_g, y_g, z_g;
 
   void writeRegister8(uint8_t reg, uint8_t value);
- private:
+ protected:
   uint8_t readRegister8(uint8_t reg);
+ private:
   int32_t _sensorID;
   int8_t  _i2caddr;
 };


### PR DESCRIPTION
In this way it can be used by derived classes.