### PR TITLE
Add support for multiple I2C buses.

### DIFF
--- a/Adafruit_MMA8451.cpp
+++ b/Adafruit_MMA8451.cpp
@@ -13,7 +13,8 @@
 
     @section  HISTORY
 
-    v1.0  - First release
+    v1.0    - First release
+    2017.04 - Add support for multiple I2C buses (Max Vilimpoc / unu GmbH)
 */
 /**************************************************************************/
 
@@ -23,7 +24,6 @@
  #include "WProgram.h"
 #endif
 
-#include <Wire.h>
 #include <Adafruit_MMA8451.h>
 
 /**************************************************************************/
@@ -31,19 +31,19 @@
     @brief  Abstract away platform differences in Arduino wire library
 */
 /**************************************************************************/
-static inline uint8_t i2cread(void) {
+uint8_t Adafruit_MMA8451::i2cread(void) {
   #if ARDUINO >= 100
-  return Wire.read();
+  return _wire.read();
   #else
-  return Wire.receive();
+  return _wire.receive();
   #endif
 }
 
-static inline void i2cwrite(uint8_t x) {
+void Adafruit_MMA8451::i2cwrite(uint8_t x) {
   #if ARDUINO >= 100
-  Wire.write((uint8_t)x);
+  _wire.write((uint8_t)x);
   #else
-  Wire.send(x);
+  _wire.send(x);
   #endif
 }
 
@@ -54,10 +54,10 @@ static inline void i2cwrite(uint8_t x) {
 */
 /**************************************************************************/
 void Adafruit_MMA8451::writeRegister8(uint8_t reg, uint8_t value) {
-  Wire.beginTransmission(_i2caddr);
+  _wire.beginTransmission(_i2caddr);
   i2cwrite((uint8_t)reg);
   i2cwrite((uint8_t)(value));
-  Wire.endTransmission();
+  _wire.endTransmission();
 }
 
 /**************************************************************************/
@@ -66,12 +66,12 @@ void Adafruit_MMA8451::writeRegister8(uint8_t reg, uint8_t value) {
 */
 /**************************************************************************/
 uint8_t Adafruit_MMA8451::readRegister8(uint8_t reg) {
-    Wire.beginTransmission(_i2caddr);
+    _wire.beginTransmission(_i2caddr);
     i2cwrite(reg);
-    Wire.endTransmission(false); // MMA8451 + friends uses repeated start!!
+    _wire.endTransmission(false); // MMA8451 + friends uses repeated start!!
 
-    Wire.requestFrom(_i2caddr, 1);
-    if (! Wire.available()) return -1;
+    _wire.requestFrom(_i2caddr, 1);
+    if (! _wire.available()) return -1;
     return (i2cread());
 }
 
@@ -80,19 +80,45 @@ uint8_t Adafruit_MMA8451::readRegister8(uint8_t reg) {
     @brief  Instantiates a new MMA8451 class in I2C mode
 */
 /**************************************************************************/
-Adafruit_MMA8451::Adafruit_MMA8451(int32_t sensorID) {
-  _sensorID = sensorID;
+Adafruit_MMA8451::Adafruit_MMA8451(int32_t sensorID) : _wire(Wire), _sensorID(sensorID), _i2caddr(MMA8451_DEFAULT_ADDRESS) {
 }
 
 /**************************************************************************/
 /*!
-    @brief  Setups the HW (reads coefficients values, etc.)
+    @brief  Instantiates a new MMA8451 class in I2C mode, allows using
+            more than one I2C bus on systems that support it.
+
+    If you use this constructor, be very careful using .begin() with default
+    parameters.
+
+    Instead, use .setup(), for example:
+
+    Adafruit_MMA8451 sensor(Wire1, 0x1C);
+    sensor.setup();
+    sensor.read();
+*/
+/**************************************************************************/
+Adafruit_MMA8451::Adafruit_MMA8451(WireClass & wire, uint8_t i2cAddress, int32_t sensorID) : _wire(wire), _sensorID(sensorID), _i2caddr(i2cAddress) {
+}
+
+/**************************************************************************/
+/*!
+    @brief  Starts the Wire bus on certain systems.
 */
 /**************************************************************************/
 bool Adafruit_MMA8451::begin(uint8_t i2caddr) {
-  Wire.begin();
+  _wire.begin();
   _i2caddr = i2caddr;
 
+  return setup();
+}
+
+/**************************************************************************/
+/*!
+    @brief  Sets up the HW (reads coefficients values, etc.)
+*/
+/**************************************************************************/
+bool Adafruit_MMA8451::setup() {
   /* Check connection */
   uint8_t deviceid = readRegister8(MMA8451_REG_WHOAMI);
   if (deviceid != 0x1A)
@@ -131,17 +157,16 @@ bool Adafruit_MMA8451::begin(uint8_t i2caddr) {
   return true;
 }
 
-
 void Adafruit_MMA8451::read(void) {
   // read x y z at once
-  Wire.beginTransmission(_i2caddr);
+  _wire.beginTransmission(_i2caddr);
   i2cwrite(MMA8451_REG_OUT_X_MSB);
-  Wire.endTransmission(false); // MMA8451 + friends uses repeated start!!
+  _wire.endTransmission(false); // MMA8451 + friends uses repeated start!!
 
-  Wire.requestFrom(_i2caddr, 6);
-  x = Wire.read(); x <<= 8; x |= Wire.read(); x >>= 2;
-  y = Wire.read(); y <<= 8; y |= Wire.read(); y >>= 2;
-  z = Wire.read(); z <<= 8; z |= Wire.read(); z >>= 2;
+  _wire.requestFrom(_i2caddr, 6);
+  x = _wire.read(); x <<= 8; x |= _wire.read(); x >>= 2;
+  y = _wire.read(); y <<= 8; y |= _wire.read(); y >>= 2;
+  z = _wire.read(); z <<= 8; z |= _wire.read(); z >>= 2;
 
 
   uint8_t range = getRange();

--- a/Adafruit_MMA8451.cpp
+++ b/Adafruit_MMA8451.cpp
@@ -88,14 +88,20 @@ Adafruit_MMA8451::Adafruit_MMA8451(int32_t sensorID) : _wire(Wire), _sensorID(se
     @brief  Instantiates a new MMA8451 class in I2C mode, allows using
             more than one I2C bus on systems that support it.
 
-    If you use this constructor, be very careful using .begin() with default
-    parameters.
+    If you use this constructor, be very careful using Adafruit_MMA8541::begin() 
+    with default parameters.
 
-    Instead, use .setup(), for example:
+    Instead, configure the I2C bus instance first, then use .setup().
+
+    For example, on Teensy:
 
     Adafruit_MMA8451 sensor(Wire1, 0x1C);
-    sensor.setup();
-    sensor.read();
+
+    void setup() {
+        Wire1.begin(I2C_MASTER, 0x00, I2C_PINS_16_17, I2C_PULLUP_EXT, 400000);
+        sensor.setup();
+        sensor.read();
+    }
 */
 /**************************************************************************/
 Adafruit_MMA8451::Adafruit_MMA8451(WireClass & wire, uint8_t i2cAddress, int32_t sensorID) : _wire(wire), _sensorID(sensorID), _i2caddr(i2cAddress) {


### PR DESCRIPTION
This change encapsulates the reference to the I2C bus, allowing users to use more than one I2C bus on systems that support it (i.e. Teensy LC / 3.2 / 3.5 / 3.6). This is useful for advanced users who want to get more mileage out of their hardware.

It should not break any existing code, as the code path for the original constructor and the default begin() statements will continue to use the default `Wire` instance.

The new constructor which encapsulates the I2C bus allows a user to specify and read from the device like so:

```
Adafruit_MMA8451 sensor(Wire1, 0x1C);
Wire1.begin(I2C_MASTER, 0x00, I2C_PINS_16_17, I2C_PULLUP_EXT, 400000);
sensor.setup();
sensor.read();
```

The changes were tested against Arduino IDE 1.6.13 and PlatformIO IDE 2.0.0-beta.2.