### PR TITLE
Update Adafruit_MMA8451.h

### DIFF
--- a/Adafruit_MMA8451.h
+++ b/Adafruit_MMA8451.h
@@ -142,7 +142,6 @@ public:
    */
   void writeRegister8(uint8_t reg, uint8_t value);
 
-protected:
   /*!
    * @brief Reads from 8 bit register
    * @param reg Register


### PR DESCRIPTION
Unprotected the `readRegister8` method in `Adafruit_MMA8451.h`

Leaving this function protected makes it impossible to implement some of the key features in the chip. These methods are detailed in NXPs application notes .
For example, in [AN4070](https://www.nxp.com/docs/en/application-note/AN4070.pdf) on page 11: clearing interrupts register flags is completed by a direct register read, and safely bit setting the MMA8451 control registers is completed by first reading the current register state, setting the relevant bits, and then writing the updated state.

If I have time at the completion of my project I would gladly add the features we're building into the main library, but for the time being, protecting `readRegister8` makes many of the chips features unusable with this library's current state.